### PR TITLE
fix: code selection not showed due to CSS bug

### DIFF
--- a/src/variables.css
+++ b/src/variables.css
@@ -94,7 +94,7 @@
     --color-primary-highlight: hsl(0deg, 88%, 70%);
 
     --code-text: var(--color-base);
-    --code-comment: hsl(0, 0, 50%);
+    --code-comment: hsl(0, 0%, 50%);
     --code-token-1: hsl(50, 90%, 80%);
     --code-token-2: hsl(15, 60%, 60%);
     --code-token-3: hsl(75, 20%, 50%);
@@ -103,6 +103,6 @@
     --code-deleted: hsl(15, 60%, 55%);
     --code-border: var(--color-line);
     --code-background: var(--color-highlight);
-    --code-background-selection: hsla(0,0,93%,0.15);
+    --code-background-selection: hsla(0,0%,93%,0.15);
   }
 }


### PR DESCRIPTION
The code selection is not appearing when in dark mode, tested in Firefox and Edge. This problem was originally using the simple theme for blogs provided by Lume, which uses Prism. I am not sure if this affects highlightJS.

I investigated this issue and discovered that it was caused by a problem with the specification of the CSS color in ds/src/variables.css.

It turns out that when specifying percentages, hsl and hsla color definitions should use '0%' instead of just '0'. The use of '0' instead of '0px' and similar values is only allowed for lengths, as discussed [here](https://stackoverflow.com/questions/31779146/any-bug-with-hsla0-0-0-0-becoming-hsla0-0-0-0-missing-percent-sig?noredirect=1&lq=1). However, I couldn't find any official documentation that specifically addresses this.

I also performed a quick regex search across all lumeland repositories, but I couldn't find this bug anywhere else.

Thank you for your excellent work and the support on Discord, @oscarotero ! Lume is fantastic, and I'm looking forward to seeing this fix in the next version of lume😄 :fire: 