### PR TITLE
feat: add styling to <blockquote> element

### DIFF
--- a/src/components/blockquote.css
+++ b/src/components/blockquote.css
@@ -1,0 +1,6 @@
+blockquote {
+  margin: 0;
+  padding-block: 1em;
+  padding-inline: 40px;
+  background-color: var(--color-highlight);
+}

--- a/src/main.css
+++ b/src/main.css
@@ -6,6 +6,7 @@
 
 @import "./components/badge.css";
 @import "./components/body.css";
+@import "./components/blockquote.css";
 @import "./components/breadcrumb.css";
 @import "./components/button.css";
 @import "./components/code.css";


### PR DESCRIPTION
I was using [@lumeland/theme-simple-blog](https://github.com/lumeland/theme-simple-blog) and I've noticed that `<blockquote>` tag does not have any styling. Here my styling suggestion:
![CleanShot 2024-01-02 at 15 09 50](https://github.com/lumeland/ds/assets/1800468/5e004961-d493-4278-935a-4066376b5b55)
